### PR TITLE
Add wiring descripton to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # LiquidCrystal_I2C
-LiquidCrystal Arduino library for the DFRobot I2C LCD displays
+LiquidCrystal Arduino library for the DFRobot I2C LCD displays (based on `PCF8574` port expander)
+
+## Wiring
+
+Usefull for those who use bare `PCF8574`:
+
+| PCF8574 | LCD       |
+| ------- | --------- |
+| P0      | RS        |
+| P1      | RW        |
+| P2      | E         |
+| P3      | Backlight |
+| P4      | D4        |
+| P5      | D6        |
+| P6      | D6        |
+| P7      | D7        |


### PR DESCRIPTION
It is not clear how to wire LCD to PCF (even reading source) so this info might save half hour of time to other people trying to use bare PCF (like me). 