### PR TITLE
Update LiquidCrystal_I2C.h

### DIFF
--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -48,9 +48,9 @@
 #define LCD_BACKLIGHT 0x08
 #define LCD_NOBACKLIGHT 0x00
 
-#define En B00000100  // Enable bit
-#define Rw B00000010  // Read/Write bit
-#define Rs B00000001  // Register select bit
+#define En 0b00000100  // Enable bit
+#define Rw 0b00000010  // Read/Write bit
+#define Rs 0b00000001  // Register select bit
 
 class LiquidCrystal_I2C : public Print {
 public:


### PR DESCRIPTION
Warning fix.

...\Arduino\libraries\LiquidCrystal_I2C\LiquidCrystal_I2C.h:53:12: warning: 'B00000001' is deprecated: use 0b00000001 instead [-Wdeprecated-declarations] #define En  0B00000100  // Enable bit
#define Rw 0B00000010  // Read/Write bit
#define Rs  0B00000001  // Register select bit