### PR TITLE
 Enhanced LCD Clear Function: Added support for clearing a specific row

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -129,10 +129,22 @@ void LiquidCrystal_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 }
 
 /********** high level commands, for the user! */
-void LiquidCrystal_I2C::clear(){
-	command(LCD_CLEARDISPLAY);// clear display, set cursor position to zero
+//added feature to clear particular diplay
+void LiquidCrystal_I2C::clear(uint8_t row) {
+    if (row == 255) {
+        // Clear the entire display
+        command(LCD_CLEARDISPLAY);
+        delayMicroseconds(2000);  // this command takes a long time!
+if (_oled) setCursor(0,0);
+    } else if (row < _rows) {
+		// Clear only the specified row
+        setCursor(0, row); // Move cursor to the beginning of the row
+        for (uint8_t i = 0; i < _cols; i++) {
+			write(' ');  // Overwrite with spaces
+        }
+        setCursor(0, row); // Move cursor back to the beginning
 	delayMicroseconds(2000);  // this command takes a long time!
-  if (_oled) setCursor(0,0);
+    }
 }
 
 void LiquidCrystal_I2C::home(){

--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -129,21 +129,21 @@ void LiquidCrystal_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 }
 
 /********** high level commands, for the user! */
-//added feature to clear particular diplay
-void LiquidCrystal_I2C::clear(uint8_t row) {
-    if (row == 255) {
-        // Clear the entire display
+//added feature to clear particular rows (EITHER SINGLE OR MULTIPLE)
+void LiquidCrystal_I2C::clear(std::initializer_list<uint8_t> rows) {
+    if (rows.size() == 0) {  
+        // No arguments, clear entire display
         command(LCD_CLEARDISPLAY);
-        delayMicroseconds(2000);  // this command takes a long time!
+        delayMicroseconds(2000);
 if (_oled) setCursor(0,0);
-    } else if (row < _rows) {
-		// Clear only the specified row
-        setCursor(0, row); // Move cursor to the beginning of the row
-        for (uint8_t i = 0; i < _cols; i++) {
-			write(' ');  // Overwrite with spaces
+    } else {
+        // Clear only specified rows
+        for (uint8_t row : rows) {
+            setCursor(0, row);
+            for (uint8_t i = 0; i < _cols; i++) {
+                write(' ');  // Overwrite with spaces
+            }
         }
-        setCursor(0, row); // Move cursor back to the beginning
-	delayMicroseconds(2000);  // this command takes a long time!
     }
 }
 


### PR DESCRIPTION
Updated clear() function to accept an optional row parameter.

lcd.clear(); → Clears the entire display.

lcd.clear(0); → Clears only row 0 (or any specified row).

Modified both .cpp and .h files to support this change.

Used uint8_t instead of int for memory efficiency.